### PR TITLE
core feedback ext

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -71,12 +71,11 @@ Regenerative extracts:
 	effect_desc = "Fully heals the target and encases the target in a locker."
 
 /obj/item/slimecross/regenerative/metal/core_effect(mob/living/target, mob/user)
-	target.visible_message(span_warning("The milky goo hardens and reshapes itself, encasing [target]!"))
 	var/obj/structure/closet/slimecloset = new /obj/structure/closet(target.loc)
 	slimecloset.name = "slimy closet"
 	slimecloset.desc = "Looking closer, it seems to be made of a sort of solid, opaque, metal-like goo."
 	if(!slimecloset.insert(target)) // prevents shenanigans e.g. capturing too-large mobs (megafauna)
-		target.visible_message(span_warning("The milky goo hardens and reshapes itself, but catastrophically fails to encase [target], breaking [slimecloset] open!"))
+		slimecloset.visible_message(span_warning("The milky goo hardens and reshapes itself, but catastrophically fails to encase [target], breaking [slimecloset] open!"))
 		slimecloset.bust_open()
 		slimecloset.take_damage(slimecloset.max_integrity * 0.75)
 		slimecloset.desc += " It looks like it didn't solidify correctly, though."


### PR DESCRIPTION
- changes the mobsize check to a !insert() and early return, generalizing the check to "if the locker fails to close" (to catch more possible shenanigans)
- damages the locker on failure + adds flavor to the desc for funsies
- changes the no teleport trait check to a !do_teleport() failure check

![image](https://github.com/user-attachments/assets/8eb570c8-00c9-49ce-b8ea-3be0ea078297)
![image](https://github.com/user-attachments/assets/08557a03-cce4-49cf-a790-1bb93356d861)

in the demo screenshots, Bigg McLargehuge was set to mob_size = 4 (MOB_SIZE_HUGE), preventing him from being lockered and causing the failure state
Anchor Mann was implanted with a teleport blocker/bluespace grounding implant and thus just got paralyzed for 5s instead of actually teleporting
